### PR TITLE
Session should call halted if model does not

### DIFF
--- a/toolbox/CHANGELOG.md
+++ b/toolbox/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- #16737: Session class should call halted if model does not.
+
 ## [0.1.2]
 
 - #16618: Stop requesting new training events on unregister.

--- a/toolbox/bonsai/+bonsai/CSVWriter.m
+++ b/toolbox/bonsai/+bonsai/CSVWriter.m
@@ -99,7 +99,10 @@ classdef CSVWriter
 
         function addEntry(obj, time, lastEvent, state, halted, action, config)
 
-            simTime = num2str(time);
+            simTime = '';
+            if time > -1
+                simTime = num2str(time);
+            end
             realTime = char(datetime('now', 'TimeZone', 'UTC', 'Format', 'yyyy-MM-dd:hh:mm:ss'));
             stateStr = obj.stringifyDoubles(state);
             actionStr = obj.stringifyStruct(action, obj.config.numActions, obj.config.actionSchema);

--- a/toolbox/bonsai/+bonsai/Session.m
+++ b/toolbox/bonsai/+bonsai/Session.m
@@ -154,7 +154,14 @@ classdef Session < handle
                 blank_state = zeros(1, obj.config.numStates);
                 while ~eq(obj.lastEvent, bonsai.EventTypes.EpisodeStart) && ...
                     ~eq(obj.lastEvent, bonsai.EventTypes.Unregister)
-                    obj.getNextEvent(obj.lastSequenceId, blank_state, false);
+
+                    % send halted if an episode is still running
+                    halted = false;
+                    if eq(obj.lastEvent, bonsai.EventTypes.EpisodeStep)
+                        halted = true;
+                    end
+
+                    obj.getNextEvent(-1, blank_state, halted);
                 end
             end
 


### PR DESCRIPTION
If a model stops running before an episode finishes and the model does not call halted, the Session class should detect that and send halted before trying to start a new episode.