### PR TITLE
Shift csv logging to happen after a new event is requested

### DIFF
--- a/toolbox/CHANGELOG.md
+++ b/toolbox/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- #17105: Log events to CSV right after they are received.
+
 ## [0.1.3]
 
 - #16716: Improve message for 401/403 error codes.

--- a/toolbox/CHANGELOG.md
+++ b/toolbox/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- #17105: Log events to CSV right after they are received.
+- #17105: Shift csv logging to happen after a new event is requested.
 
 ## [0.1.3]
 
@@ -22,4 +22,4 @@ Update licensing documentation.
 ## [0.1.0]
   
 Initial toolbox release.
- 
+

--- a/toolbox/bonsai/+bonsai/Session.m
+++ b/toolbox/bonsai/+bonsai/Session.m
@@ -202,11 +202,6 @@ classdef Session < handle
 
         function getNextEvent(obj, time, state, halted)
 
-            % write session data to file
-            if obj.config.csvWriterEnabled()
-                obj.csvWriter.addEntry(time, obj.lastEvent.str, state, halted, obj.lastAction, obj.episodeConfig);
-            end
-
             % request next event
             simState = containers.Map(obj.config.stateSchema, state);
             requestData = struct('sequenceId', obj.lastSequenceId, ...
@@ -259,6 +254,11 @@ classdef Session < handle
                 obj.episodeConfig = struct();
             otherwise
                 error(['Received unknown event type: ', r.type]);
+            end
+
+            % write session data to file
+            if obj.config.csvWriterEnabled()
+                obj.csvWriter.addEntry(time, obj.lastEvent.str, state, halted, obj.lastAction, obj.episodeConfig);
             end
         end
 


### PR DESCRIPTION
With this change, CSV logs will write both the state sent by the sim and the resulting action returned by the service on the same line.